### PR TITLE
use build package

### DIFF
--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -34,7 +34,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m build
+        python -m build --no-isolation
         twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
     - name: Get version and tag
       run: |

--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools twine build
+        pip install setuptools twine build wheel
         pip install scipion-pyworkflow scipion-em
     - name: Build and publish
       env:

--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -27,15 +27,14 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        pip install scipion-pyworkflow 
-        pip install scipion-em
+        pip install setuptools twine build
+        pip install scipion-pyworkflow scipion-em
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
     - name: Get version and tag
       run: |

--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -29,6 +29,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools twine build wheel
         pip install scipion-pyworkflow scipion-em
+    - name: Check extra requirements
+      if: ${{ hashFiles('requirements.txt') != '' }}
+      run: pip install -r requirements.txt  
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
Motivation: https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
python setup.py and the use of setup.py as a command line tool are deprecated. Wheel is not required anymore.
