### PR TITLE
new centralized workflow

### DIFF
--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -1,0 +1,42 @@
+# Workflow to send master to pypi and tag the branch
+name: master to pypi with comments and tag
+
+# Triggers the workflow on push to the master branch
+# In a reusable workflow the inputs will be passed from a caller workflow
+on:
+  push:
+    branches: [ master ]
+  workflow_call:
+    inputs:
+      folder:
+        description: 'Name of the folder that contains __version__'
+        required: true
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  reusable_workflow_job:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools twine build
+        pip install scipion-pyworkflow scipion-em
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m build
+        twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
+    - name: Get version and tag
+      run: |
+        export PACKAGE_VERSION=$(python -c "import ${{ inputs.folder }}; print('VERSION', 'v'+${{ inputs.folder }}.__version__)" | grep VERSION | sed "s/VERSION //g")
+        git tag $PACKAGE_VERSION
+        git push origin $PACKAGE_VERSION

--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools twine build
+        pip install setuptools twine build wheel
         pip install scipion-pyworkflow scipion-em
     - name: Build and publish
       env:

--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -28,6 +28,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools twine build wheel
         pip install scipion-pyworkflow scipion-em
+    - name: Check extra requirements
+      if: ${{ hashFiles('requirements.txt') != '' }}
+      run: pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/.github/workflows/publish_and_tag.yml
+++ b/.github/workflows/publish_and_tag.yml
@@ -33,7 +33,7 @@ jobs:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: |
-        python -m build
+        python -m build --no-isolation
         twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
     - name: Get version and tag
       run: |

--- a/workflow-templates/publish_and_tag.properties.json
+++ b/workflow-templates/publish_and_tag.properties.json
@@ -1,12 +1,7 @@
 {
     "name": "Publish and tag",
     "description": "Workflow to publish master branch and tag it using standard __version__ approach as recommended at https://packaging.python.org/guides/single-sourcing-package-version/ sixth item.",
+    "creator": "I2PC team"
     "iconName": "pypi",
-    "categories": [
-        "Go"
-    ],
-    "filePatterns": [
-        "package.json$",
-        "^Dockerfile*"
-    ]
+    "categories": ["deployment"]
 }

--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -1,44 +1,16 @@
-# Workflow to send master to pypi and tag  the branch:
-# You need to edit FOLDER_WITH_VERSION with the folder that has the __version__ value. 
+# Workflow to send master to pypi and tag the branch
+# You need to edit folder var with the folder that has the __version__ value. 
 
 name: master to pypi with comments and tag
 
-
-# Controls when the action will run. Triggers the workflow on push or pull request
-# events but only for the master branch
+# Triggers the workflow on push to the master branch
 on:
   push:
     branches: [ master ]
 
-env:
-  FOLDER_WITH_VERSION: ???
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  deploy:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        pip install scipion-pyworkflow 
-        pip install scipion-em
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/* -c "${{ secrets.PYPI_COMMENT }}"
-    - name: Get version and tag
-      run: |
-        export PACKAGE_VERSION=$(python -c "import $FOLDER_WITH_VERSION; print('VERSION', 'v'+$FOLDER_WITH_VERSION.__version__)" | grep VERSION | sed "s/VERSION //g")
-        git tag $PACKAGE_VERSION
-        git push origin $PACKAGE_VERSION
+  call-publish-workflow:
+    uses: scipion-em/.github/.github/workflows/publish_and_tag.yml@test
+    with:
+      folder: ???
+    secrets: inherit

--- a/workflow-templates/publish_and_tag.yml
+++ b/workflow-templates/publish_and_tag.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   call-publish-workflow:
-    uses: scipion-em/.github/.github/workflows/publish_and_tag.yml@test
+    uses: scipion-em/.github/.github/workflows/publish_and_tag.yml@master
     with:
       folder: ???
     secrets: inherit


### PR DESCRIPTION
- using recommended `python -m build` instead of `setup.py sdist`  which is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/)
- install plugin requirements.txt if the file exists. This is necessary because when we parse the version we import plugin's `__init__.py` which might have other packages imported inside (besides pwem etc.). Normally build package will handle all the dependencies that are listed in setup.py `install_requires`
- new workflow accepts plugin folder name as a required string parameter, in the future we can pass more parameters if we want
- the updated workflow-templates/publish_and_tag.yml is still available on marketplace, so when a new plugin needs an action it will be used as a template that executes the main workflow

The most daunting task would be to update all plugins, but at least this will be the last time. All future updates are now centralized into one file.